### PR TITLE
docs/replace secuirty email contacts

### DIFF
--- a/docs/SECURITY
+++ b/docs/SECURITY
@@ -7,7 +7,7 @@ This document outlines security procedures and general policies for the `migaloo
 ## Reporting a Bug
 Security is something we take seriously at White Whale. Thanks for taking the time to improve the security of `migaloo-frontend`. We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
-Please report security bugs by emailing White Whale's CTO at sencommunis@protonmail.com or the repository administrator at 0xfable@protonmail.com. Do not report it publicly on the GitHub issues tracker. Your report should detail the necessary steps to reproduce the security issue. We will acknowledge your email within 48 hours and send a detailed response indicating the next steps. After the initial reply to your report, we will keep you informed of the progress towards a fix and full announcement and may ask for additional information or guidance.
+Please report security bugs by emailing White Whale at security@whitewhale.money. Do not report it publicly on the GitHub issues tracker. Your report should detail the necessary steps to reproduce the security issue. We will acknowledge your email within 48 hours and send a detailed response indicating the next steps. After the initial reply to your report, we will keep you informed of the progress towards a fix and full announcement and may ask for additional information or guidance.
 
 Report security bugs in third-party modules to the person or team maintaining the module.
 


### PR DESCRIPTION
## Description and Motivation
This PR replaces all security contact emails with the new White Whale security email.

## Related Issues

---

## Checklist:
- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-frontend/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `yarn lint`.
- [x] The project builds and is able to deploy on Netlify `yarn build`.
